### PR TITLE
Add detailed error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ droplet { ['test-digitalocean', 'test-digitalocean-1']:
   ensure => present,
   region => 'lon1',
   size   => '512mb',
-  image  => 5141286,
+  image  => 17154032,
 }
 ```
 
@@ -30,7 +30,7 @@ droplet { ['test-digitalocean', 'test-digitalocean-1']:
   ensure             => present,
   region             => 'lon1',
   size               => '512mb',
-  image              => 5141286,
+  image              => 17154032,
   ssh_keys           => [12345], # note this is an array
   backups            => false,
   ipv6               => false,

--- a/lib/puppet/provider/digitalocean_domain/v2.rb
+++ b/lib/puppet/provider/digitalocean_domain/v2.rb
@@ -53,14 +53,14 @@ Puppet::Type.type(:digitalocean_domain).provide(:v2) do
       Puppet.info("Created new domain called #{name}")
       @property_hash[:ensure] = :present
     else
-      fail 'Failed to create domain'
+      fail "Failed to create domain: #{response.message}"
     end
   end
 
   def destroy
     Puppet.info("Destroying domain #{resource[:name]}")
     response = @client.domain.destroy(resource[:name])
-    fail('Failed to destroy domain') unless response.success?
+    fail("Failed to destroy domain: #{response.message}") unless response.success?
     @property_hash[:ensure] = :absent
   end
 end

--- a/lib/puppet/provider/droplet/v2.rb
+++ b/lib/puppet/provider/droplet/v2.rb
@@ -101,7 +101,7 @@ Puppet::Type.type(:droplet).provide(:v2) do
     Puppet.info("Destroying droplet #{name}")
     if droplet
       response = @client.droplet.destroy(droplet.id)
-      fail("Failed to destroy droplet #{name}") unless response.success?
+      fail("Failed to destroy droplet #{name}: #{response.message}") unless response.success?
       @property_hash[:ensure] = :absent
     end
   end


### PR DESCRIPTION
Was trying to run the example, but the ID for Ubuntu had changed, so it just failed without saying that the image was invalid. This gives the response error message.

Before:

```
Error: /Stage[main]/Main/Droplet[puppet-master-digitalocean]/ensure: change from absent to present failed: Failed to create droplet
```

After:

```
Error: Failed to create droplet: You specified an invalid image for Droplet creation.
Error: /Stage[main]/Main/Droplet[puppet-master-digitalocean]/ensure: change from absent to present failed: Failed to create droplet: You specified an invalid image for Droplet creation.
Notice: Finished catalog run in 1.13 seconds
```

Also fixed the example to working version :+1: 
