### PR TITLE
Add working puppet enterprise example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Examples
+
+The following examples demonstrate using the DigitalOcean module to create
+infrastructure.
+
+* [Puppet Enterprise](puppet-enterprise/) - quickly startup a small
+  Puppet Enterprise cluster using the DigitalOcean module

--- a/examples/puppet-enterprise/README.md
+++ b/examples/puppet-enterprise/README.md
@@ -1,0 +1,91 @@
+# Puppet Enterprise
+
+[Puppet Enterprise](http://puppetlabs.com/puppet/puppet-enterprise) is free for up to 10 nodes,
+and a great way of getting started with Puppet. This example brings up a Puppet Master and one agent.
+
+## What
+
+```
+                                      443
+                                       +
+                                       |
+                                       |
+                   +-------------------|-------------------+
+                   |          +--------v--------+          |
+                   |          |                 |          |
+                   |          |  puppet-master  |          |
+                   |          |                 |          |
+ puppet-enterprise |          +-----------------+          |
+                   |          +-----------------+          |
+                   |          |                 |          |
+                   |          |  puppet-agent   |          |
+                   |          |                 |          |
+                   |          +-----------------+          |
+                   +---------------------------------------+
+
+```
+
+
+## How
+
+This example is in two parts, first we'll bring up the Puppet Master. And after
+making a quick configuration change we'll bring up the Puppet agents.
+
+With the module installed as described in the README, from this
+directory run:
+
+    puppet apply pe_master.pp --test --templatedir templates
+
+This will bring up the master. Please note that this could take up to 10
+minutes.
+
+We now need to modify the `pe_agent.pp` manifest so it points at the newly created
+master. Open your DigitalOcean portal, get the IP for the master, then open up `pe_agent.pp` and change the line:
+
+    $pe_master_ip       = 'change-this-ip'
+
+Alternatively you can use the Puppet resource commands:
+
+    $ puppet resource droplet puppet-master
+
+This should return a Puppet resource, including the public_address:
+
+```puppet
+droplet { 'puppet-master':
+  ensure         => 'present',
+  image          => '9801950',
+  public_address => '171.62.19.42',
+  region         => 'lon1',
+}
+```
+
+Finally you can run:
+
+    puppet apply pe_agent.pp --test --templatedir templates
+
+Now lets login to your new Puppet Enterprise console. Retrieve the public_address address
+of the `puppet-master` instance from the DigitalOcean console or using `puppet resource`, then visit:
+
+    https://your-masters-ip-address
+
+You can login with the username `admin` and the password `puppetlabs`,
+or you can change these in the `pe_agent.pp` file mentioned above.
+
+Note the https part: Because we're just using a temporary IP address here you'll likely
+get a certificate error from your browser, ignore this for now.
+
+You can learn more about using Puppet Enterprise from the comprehensive
+[user guide](https://docs.puppetlabs.com/pe/latest/)
+
+# Caveats
+
+This example is a good Proof of Concept of how to setup Puppet Enterprise inside DigitalOcean, but has a few rough edges, specifically:
+
+* The use of cloud-init to bootstrap masters and agents is limited to certain images:
+
+> CloudInit is currently available on DigitalOcean's latest CoreOS, Ubuntu 14.04, and CentOS 7 images.
+
+[Taken from An Introduction to Droplet Metadata, 24/02/2015](https://www.digitalocean.com/community/tutorials/an-introduction-to-droplet-metadata)
+
+* You need to run the manifests seperately, and manually change the IP for the master before running the agent code
+* All certificates from agents are automatically signed by the master

--- a/examples/puppet-enterprise/pe_agent.pp
+++ b/examples/puppet-enterprise/pe_agent.pp
@@ -1,0 +1,14 @@
+$pe_master_hostname = 'puppet-master'
+$pe_master_ip       = 'change-this-ip'
+$pe_version_string = '3.7.2'
+
+droplet { ['puppet-agent']:
+  ensure             => present,
+  region             => 'lon1',
+  size               => '1gb',
+  image              => 9801950, # Ubuntu 14.04.1 64bit LTS
+  backups            => false,
+  ipv6               => false,
+  private_networking => false,
+  user_data          => template('agent-pe-userdata.erb'),
+}

--- a/examples/puppet-enterprise/pe_master.pp
+++ b/examples/puppet-enterprise/pe_master.pp
@@ -1,0 +1,21 @@
+$pe_version_string = '3.7.2'
+$pe_password = 'puppetlabs'
+
+if versioncmp($pe_version_string, '3.7.0') >= 0 {
+  # PE > 3.7 doesn't like email usernames
+  $pe_username = 'admin'
+}
+else {
+  $pe_username = 'admin@puppetlabs.com'
+}
+
+droplet { ['puppet-master']:
+  ensure             => present,
+  region             => 'lon1',
+  size               => '8gb',
+  image              => 9801950, # Ubuntu 14.04.1 64bit LTS
+  backups            => false,
+  ipv6               => false,
+  private_networking => false,
+  user_data          => template('master-pe-userdata.erb'),
+}

--- a/examples/puppet-enterprise/templates/agent-pe-userdata.erb
+++ b/examples/puppet-enterprise/templates/agent-pe-userdata.erb
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+
+echo "<%= @pe_master_ip %>  <%= @pe_master_hostname %> master" >> /etc/hosts
+
+PE_MASTER='<%= @pe_master_hostname %>'
+
+PE_CERTNAME=$(curl -s http://169.254.169.254/metadata/v1/hostname)
+
+curl -sk https://$PE_MASTER:8140/packages/current/install.bash | /bin/bash -s agent:certname=$PE_CERTNAME

--- a/examples/puppet-enterprise/templates/master-pe-userdata.erb
+++ b/examples/puppet-enterprise/templates/master-pe-userdata.erb
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+#username for the console:
+PUPPET_PE_CONSOLEADMIN='<%= @pe_username %>'
+#password for the console:
+PUPPET_PE_CONSOLEPWD='<%= @pe_password %>'
+
+PUPPET_PE_VERSION='<%= @pe_version_string %>'
+
+RESULTS_FILE='/tmp/puppet_bootstrap_output'
+S3_BASE='https://s3.amazonaws.com/pe-builds/released/'
+
+function check_exit_status() {
+  if [ ! -f $RESULTS_FILE ]; then
+    echo '1' > $RESULTS_FILE
+  fi
+}
+
+trap check_exit_status INT TERM EXIT
+
+function write_masteranswers() {
+  cat > /opt/masteranswers.txt << ANSWERS
+q_all_in_one_install=y
+q_backup_and_purge_old_configuration=n
+q_backup_and_purge_old_database_directory=n
+q_database_host=localhost
+q_database_install=y
+q_install=y
+q_pe_database=y
+q_puppet_cloud_install=y
+q_puppet_enterpriseconsole_auth_password=$PUPPET_PE_CONSOLEPWD
+q_puppet_enterpriseconsole_auth_user_email=$PUPPET_PE_CONSOLEADMIN
+q_puppet_enterpriseconsole_httpd_port=443
+q_puppet_enterpriseconsole_install=y
+q_puppet_enterpriseconsole_master_hostname=$DO_HOSTNAME
+q_puppet_enterpriseconsole_smtp_host=localhost
+q_puppet_enterpriseconsole_smtp_password=
+q_puppet_enterpriseconsole_smtp_port=25
+q_puppet_enterpriseconsole_smtp_use_tls=n
+q_puppet_enterpriseconsole_smtp_user_auth=n
+q_puppet_enterpriseconsole_smtp_username=
+q_puppet_symlinks_install=y
+q_puppetagent_certname=$DO_HOSTNAME
+q_puppetagent_install=y
+q_puppetagent_server=$DO_HOSTNAME
+q_puppetdb_hostname=$DO_HOSTNAME
+q_puppetdb_install=y
+q_puppetdb_port=8081
+q_puppetmaster_certname=$DO_HOSTNAME
+q_puppetmaster_dnsaltnames=$DO_HOSTNAME,puppet
+q_puppetmaster_enterpriseconsole_hostname=localhost
+q_puppetmaster_enterpriseconsole_port=443
+q_puppetmaster_install=y
+q_run_updtvpkg=n
+q_vendor_packages_install=y
+ANSWERS
+}
+
+function write_sitepp() {
+  cat > /etc/puppetlabs/puppet/manifests/site.pp << SITEPP
+filebucket { 'main':
+  server => \$servername,
+  path   => false,
+}
+
+File { backup => 'main' }
+
+Package { allow_virtual => false }
+
+node default {
+  include pe_mcollective
+}
+SITEPP
+}
+
+function install_puppetmaster() {
+  if [ ! -d /opt/puppet-enterprise ]; then
+    mkdir -p /opt/puppet-enterprise
+  fi
+  if [ ! -f /opt/puppet-enterprise/puppet-enterprise-installer ]; then
+    case ${breed} in
+      "redhat")
+        ntpdate -u 0.north-america.pool.ntp.org
+        curl -s -o /opt/pe-installer.tar.gz "https://s3.amazonaws.com/pe-builds/released/$PUPPET_PE_VERSION/puppet-enterprise-$PUPPET_PE_VERSION-el-6-x86_64.tar.gz" ;;
+      "ubuntu")
+        UBUNTU_RELEASE=$(sed -ne 's/DISTRIB_RELEASE=\(.*\)/\1/gp' /etc/lsb-release)
+        ARCH=$(uname -m)
+        curl -s -o /opt/pe-installer.tar.gz "https://s3.amazonaws.com/pe-builds/released/$PUPPET_PE_VERSION/puppet-enterprise-$PUPPET_PE_VERSION-ubuntu-$UBUNTU_RELEASE-amd64.tar.gz" ;;
+      "debian")
+        curl -s -o /opt/pe-installer.tar.gz "https://s3.amazonaws.com/pe-builds/released/$PUPPET_PE_VERSION/puppet-enterprise-$PUPPET_PE_VERSION-debian-7-amd64.tar.gz" ;;
+    esac
+    #Drop installer in predictable location
+    tar --extract --file=/opt/pe-installer.tar.gz --strip-components=1 --directory=/opt/puppet-enterprise
+  fi
+  write_masteranswers
+  /opt/puppet-enterprise/puppet-enterprise-installer -a /opt/masteranswers.txt
+}
+
+function download_modules() {
+  /opt/puppet/bin/puppet module upgrade puppetlabs-stdlib
+  if [ -n $1 ]; then
+    MODULE_LIST=`echo "$1" | sed 's/,/ /g'`
+    for i in $MODULE_LIST; do /opt/puppet/bin/puppet module install --force $i ; done;
+  fi
+}
+
+function clone_modules() {
+  if [ -n "$1" ]; then
+    #get git, regardless of platform
+    apt-get install -y git-core 2>/dev/null || yum install -y git 2>/dev/null
+    pushd /etc/puppetlabs/puppet/modules
+    MODULE_LIST=`echo "$1" | sed 's/,/ /g'`
+    for i in $MODULE_LIST; do
+      MODULE=`echo "$i" | sed 's/#/ /'`
+      if [ ! -d `echo $MODULE | cut -d' ' -f2` ]; then
+        git clone $MODULE ;
+      fi
+    done;
+    popd
+  fi
+}
+
+function classify_master () {
+  declare -a class_array=($PUPPET_PE_CLASSES)
+  for class in ${class_array[@]}; do
+    /opt/puppet/bin/rake -f /opt/puppet/share/puppet-dashboard/Rakefile RAILS_ENV=production nodeclass:add["${class}",'skip']
+    /opt/puppet/bin/rake -f /opt/puppet/share/puppet-dashboard/Rakefile RAILS_ENV=production node:addclass[`hostname -f`,"${class}"]
+  done
+}
+
+function provision_puppet() {
+  if [ -f /etc/redhat-release ]; then
+    export breed='redhat'
+    setenforce 0
+  elif [ -f /etc/issue ]; then
+    export breed='ubuntu'
+  elif [ -f /etc/debian_version ]; then
+    export breed='debian'
+  else
+    echo "This OS is not supported"
+    exit 1
+  fi
+
+  DO_HOSTNAME=$(curl http://169.254.169.254/metadata/v1/hostname)
+
+  install_puppetmaster
+  download_modules "puppetlabs-ntp,puppetlabs-apache"
+  clone_modules    "$PUPPET_REPOS"
+  classify_master
+  write_sitepp
+
+  echo "*" > /etc/puppetlabs/puppet/autosign.conf
+
+  /opt/puppet/bin/puppet agent --onetime --no-daemonize --color=false --verbose
+
+  echo $? > $RESULTS_FILE
+  echo "Puppet installation finished!"
+  exit 0
+}
+
+provision_puppet


### PR DESCRIPTION
Adds Puppet Enterprise Example

This spins up a Ubuntu 14.04 Master and Agent

Reworks some of the existing code from https://github.com/puppetlabs/puppetlabs-aws
